### PR TITLE
remove z-shell/zsh-fancy-completions

### DIFF
--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -50,7 +50,7 @@ zi_annex_meta_plugins_map=(
   annexes+ "annexes z-shell/z-a-submods z-shell/z-a-test"
   
   # @z-shell
-  z-shell     "z-shell/F-Sy-H z-shell/H-S-MW z-shell/zsh-diff-so-fancy z-shell/zsh-fancy-completions"
+  z-shell     "z-shell/F-Sy-H z-shell/H-S-MW z-shell/zsh-diff-so-fancy"
   z-shell+    "z-shell/zsh-select z-shell/zconvey z-shell/zui z-shell/zflai"
 
   # @zsh-users
@@ -122,7 +122,6 @@ zi_annex_meta_plugins_config_map=(
   z-shell/F-Sy-H                      "$_std atinit'ZI[COMPINIT_OPTS]=-C; zicompinit; zicdreplay;' atload'fast-theme z-shell &>/dev/null;'"
   z-shell/H-S-MW                      "$_std atinit'zstyle :history-search-multi-word page-size 7;'"
   z-shell/zsh-diff-so-fancy           "$_std null sbin'bin/git-dsf;bin/diff-so-fancy'"
-  z-shell/zsh-fancy-completions       "$_std compile'functions/.*{initialization,zstyle}'"
   
   # @z-shell, less popular
   z-shell/zui             "$_std blockf"

--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -4,17 +4,17 @@
 # Copyright (c) 2021 Z-Shell Community
 #
 # Zsh Plugin Standard
-# https://z.digitalclouds.dev/community/zsh_plugin_standard#zero-handling
+# https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling
 0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
-# https://z.digitalclouds.dev/community/zsh_plugin_standard/#funtions-directory
+# https://wiki.zshell.dev/community/zsh_plugin_standard/#funtions-directory
 if [[ $PMSPEC != *f* ]] {
   fpath+=( "${0:h}/functions" )
 }
 
 # Standard hash for plugins:
-# https://z.digitalclouds.dev/community/zsh_plugin_standard#standard-plugins-hash
+# https://wiki.zshell.dev/community/zsh_plugin_standard#standard-plugins-hash
 typeset -gA zi_annex_meta_plugins
 zi_annex_meta_plugins[0]="$0" 
 zi_annex_meta_plugins[repo-dir]="${0:h}"
@@ -55,7 +55,7 @@ zi_annex_meta_plugins_map=(
 
   # @zsh-users
   zsh-users       "zsh-users/zsh-syntax-highlighting zsh-users/zsh-autosuggestions zsh-users/zsh-completions"
-  zsh-users+fast  "z-shell/F-Sy-H zsh-users/zsh-autosuggestions zsh-users/zsh-completions"
+  zsh-users+fast  "z-shell/F-Sy-H zsh-users/zsh-autosuggestions zsh-users/zsh-completions z-shell/zsh-fancy-completions"
 
   # @romkatv
   romkatv    "romkatv/powerlevel10k"
@@ -122,7 +122,8 @@ zi_annex_meta_plugins_config_map=(
   z-shell/F-Sy-H                      "$_std atinit'ZI[COMPINIT_OPTS]=-C; zicompinit; zicdreplay;' atload'fast-theme z-shell &>/dev/null;'"
   z-shell/H-S-MW                      "$_std atinit'zstyle :history-search-multi-word page-size 7;'"
   z-shell/zsh-diff-so-fancy           "$_std null sbin'bin/git-dsf;bin/diff-so-fancy'"
-  
+  z-shell/zsh-fancy-completions       "$_std"
+
   # @z-shell, less popular
   z-shell/zui             "$_std blockf"
   z-shell/zconvey         "$_std sbin'cmds/zc-bg-notify;cmds/plg-zsh-notify'"


### PR DESCRIPTION
z-shell/zsh-fancy-completions has either been deleted or privated, it is no longer on github and this breaks the @z-shell meta annex. There should be some guidelines on this added from maintainers. just deleting the repo with cleaning up elsewhere is bound to cause a lot of problems.