### PR TITLE
ci(trunk): refresh caller workflow

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -1,23 +1,30 @@
 ---
-name: "⭕ Trunk"
+name: Trunk Code Quality
+
 on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 05 * * 5"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
-    if: github.event.schedule != '0 05 * * 5'
-    name: "⚡"
+    name: Trunk Code Quality
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     uses: z-shell/.github/.github/workflows/trunk.yml@main
-  upload:
-    if: github.event.schedule == '0 05 * * 5'
-    name: "🆙"
-    uses: z-shell/.github/.github/workflows/trunk.yml@main
-    secrets:
-      trunk-token: ${{ secrets.TRUNK_TOKEN }}
+    with:
+      arguments: --no-progress


### PR DESCRIPTION
## Summary

- Update the Trunk caller workflow to the refreshed org-level single-job shape from z-shell/.github#404.
- Remove the deprecated scheduled upload job and `TRUNK_TOKEN` path.
- Add explicit permissions, concurrency, and `arguments: --no-progress`.

Part of z-shell/.github#408.

## Verification

- Compared branch against `main`: one-file workflow-only diff.
- YAML shape reviewed after writing `.github/workflows/trunk-check.yml`.

## Agent handoff

**Status:** Ready for review
**Current state:** PR contains only the Trunk caller refresh for `.github/workflows/trunk-check.yml`.
**Blockers:** None known.
**Next steps:** Wait for PR CI; merge if green.