### PR TITLE
ci(workflows): add permissions + concurrency to zsh-n

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -15,6 +15,13 @@ on:
       - "functions/*"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zsh-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ZSH-1 CI modernization (perms/concurrency sweep). zsh-n was missing both a top-level `permissions` block and `concurrency`. Adds read-only `permissions` and the standard concurrency group.