### PR TITLE
fix(meta-plugins): reinstall completions from absolute path

### DIFF
--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -114,7 +114,7 @@ zi_annex_meta_plugins_config_map=(
   # @zsh-users
   zsh-users/zsh-syntax-highlighting   "$_std atinit'ZI[COMPINIT_OPTS]=-C; zicompinit; zicdreplay;'"
   zsh-users/zsh-autosuggestions       "$_std compile'{src/*.zsh*~*.zwc,src/strategies/*~*.zwc}' atload'!_zsh_autosuggest_start;'"
-  zsh-users/zsh-completions           "$_std atpull'zi creinstall -q .' pick'/dev/null'"
+  zsh-users/zsh-completions           "$_std atpull'zi creinstall \$PWD' pick'/dev/null'"
 
   # @z-shell
   z-shell/F-Sy-H                      "$_std atinit'ZI[COMPINIT_OPTS]=-C; zicompinit; zicdreplay;' atload'fast-theme z-shell &>/dev/null;' compile'{functions/{.fast,fast}-*~*.zwc,chroma/*~*.zwc}'"


### PR DESCRIPTION
## Summary

- run the `zsh-users/zsh-completions` at-pull reinstall against the absolute plugin directory
- avoid broken relative completion symlinks such as `./src/_demo` resolving from Zi's completions directory

Closes #23

## Verification

- `zsh -n z-a-meta-plugins.plugin.zsh functions/.za-meta-plugins-before-load-handler`
- `git diff --check`
- sourced the annex with a stubbed registration hook and confirmed the stored ice is `atpull'zi creinstall $PWD'`
- isolated Zi harness: reproduced broken relative targets from both `zi creinstall -q .` and `zi creinstall .`, then verified `zi creinstall $PWD` creates an absolute resolving symlink and `zi clist` reports the completion source correctly