### PR TITLE
ci(labels): use canonical label names in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,15 @@
-documentation 📝:
+type:docs:
   - "docs/**/*.md"
   - "community/**/*.md"
   - "ecosystem/**/*.md"
-dependencies 📦:
+area:dependencies:
   - "package.json"
   - "pnpm-lock.yaml"
   - "yarn.lock"
-enhancement ✨:
+type:maintenance:
   - "functions/**"
   - "src/**"
   - "lib/**"
-maintenance 📈:
   - ".all-contributorsrc"
   - ".deepsource.toml"
   - ".editorconfig"
@@ -33,16 +32,7 @@ maintenance 📈:
   - "crowdin.yml"
   - "netlify.toml"
   - "tsconfig.json"
-i18n 🌐:
-  - "i18n/**"
-  - "docs/i18n/**"
-annex 🌀:
+area:annex:
   - "*"
-#package 📦:
-#  - 'ecosystem/packages/**/*.md'
-#  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/packages/**/*.md'
-#plugin ⚙️:
-#  - 'ecosystem/plugins/**.md'
-#  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/plugins/**/*.md'
-ci 🤖:
+area:ci:
   - ".github/workflows/*"


### PR DESCRIPTION
`.github/labeler.yml` referenced legacy labels that [z-shell/.github#467](https://github.com/z-shell/.github/issues/467) deleted across the organization.

| Was | Now |
| --- | --- |
| `documentation 📝` | `type:docs` |
| `dependencies 📦` | `area:dependencies` |
| `enhancement ✨` | `type:maintenance` |
| `maintenance 📈` | `type:maintenance` |
| `annex 🌀` | `area:annex` |
| `ci 🤖` | `area:ci` |
| `i18n 🌐` | removed |

Keys go from 7 to 5, globs from 35 to 33. The only globs removed are the two `i18n` ones.

## This repository has no labeler workflow

Nothing consumes this file today: `.github/workflows/` contains `trunk-check.yml`, `zsh-lint.yml`, and `zsh-n.yml`, with no `actions/labeler` step anywhere. So this is hygiene rather than a fix for observed behavior, and it carries no risk.

It still matters. An orphaned config invites someone to add the workflow later, and `actions/labeler` applies labels through the issues API, which **creates** a label that does not exist rather than failing. Adding the workflow against this file as it stands would silently recreate the deleted legacy labels.

## Three things worth a look rather than a skim

- **`enhancement ✨` and `maintenance 📈` both map to `type:maintenance`**, so their glob lists merge into a single key rather than being renamed one for one. Changes under `functions/**`, `src/**`, and `lib/**` now get `type:maintenance` alongside the repository-metadata globs that already produced it.
- **`i18n 🌐` is dropped, not translated.** It has no canonical equivalent and this repository has never used it. The only repository in the organization that does is `z-shell/wiki`, which does not drive it from a labeler config.
- **The commented-out `#package 📦` and `#plugin ⚙️` blocks are gone.** The file is re-emitted from parsed YAML, which does not preserve comments. They were disabled Docusaurus leftovers referencing paths this repository does not have, so nothing active is lost, but it is a real difference from the diff you might expect.

The same template origin explains the remaining `docusaurus.config.js`, `crowdin.yml`, `babel.config.js`, and `netlify.toml` globs, which match nothing here. Pruning those would be a genuine improvement and is deliberately left out, so this stays reviewable as a label-name correction.

## Verified

Parsed with `yaml.safe_load` and checked against `lib/labels.yml`: all five resulting keys are canonical, and the audit added in [z-shell/.github#529](https://github.com/z-shell/.github/pull/529) reports no findings for the result.

Part of z-shell/.github#527.
