### PR TITLE
feat(meta-plugins): restore Prezto group

### DIFF
--- a/tests/prezto-meta-plugin.zsh
+++ b/tests/prezto-meta-plugin.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+setopt extended_glob pipe_fail
+
+typeset repo_dir=${0:A:h:h}
+
+fail() {
+  builtin emulate -L zsh
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+function @zi-register-annex() { :; }
+
+typeset -g PMSPEC=f
+typeset -gA ICE ZI
+typeset -ga zsh_loaded_plugins
+builtin source "$repo_dir/z-a-meta-plugins.plugin.zsh" >/dev/null || fail "source meta-plugins annex"
+
+[[ ${zi_annex_meta_plugins_map[prezto]} = "PZTM::archive PZTM::directory PZTM::utility" ]] || \
+  fail "register @prezto members"
+[[ ${zi_annex_meta_plugins_config_map[PZTM::archive]} = "lucid is-snippet svn silent nocompile" ]] || \
+  fail "configure archive as a directory snippet"
+[[ ${zi_annex_meta_plugins_config_map[PZTM::directory]} = "lucid is-snippet" ]] || \
+  fail "configure directory as a file snippet"
+[[ ${zi_annex_meta_plugins_config_map[PZTM::utility]} = "lucid is-snippet" ]] || \
+  fail "configure utility as a file snippet"
+(( !${+zi_annex_meta_plugins_map[ohmyzsh-svn-lib]} )) || fail "leave @ohmyzsh-svn-lib unavailable"
+
+function .zi-get-object-path() { return 1; }
+function .zi-any-colorify-as-uspl2() { REPLY=$1; }
+function .zi-two-paths() { :; }
+function +zi-message() { :; }
+
+run_prezto_handler() {
+  builtin source "$repo_dir/functions/.za-meta-plugins-before-load-handler" \
+    plugin @prezto @prezto '' '' hook subtype
+}
+
+run_prezto_handler
+integer handler_rc=$?
+(( handler_rc == 2 )) || fail "expand @prezto through the before-load handler"
+typeset -a expected_parts=(
+  "lucid is-snippet svn silent nocompile @PZTM::archive"
+  "lucid is-snippet @PZTM::directory"
+  "lucid is-snippet @PZTM::utility"
+)
+typeset expected_expansion=${(j: :)expected_parts}
+typeset actual_expansion=${ZI[annex-before-load:new-@]%%[[:space:]]#}
+[[ $actual_expansion = "$expected_expansion" ]] || fail "apply restored Prezto ice configuration"
+
+builtin print -r -- "ok - register only the restored Prezto meta-plugin"

--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -88,6 +88,9 @@ zi_annex_meta_plugins_map=(
   # Python utilities.
   py-utils    "pyenv"
 
+  # A few Prezto modules. The archive module uses Zi's Git sparse directory backend.
+  prezto      "PZTM::archive PZTM::directory PZTM::utility"
+
   # Oh-My-Zsh library with positive or commonly required effects.
   ohmyzsh-lib "OMZL::git OMZL::history OMZL::vcs_info OMZL::clipboard OMZL::completion OMZL::theme-and-appearance OMZL::prompt_info_functions OMZL::termsupport OMZL::key-bindings OMZL::compfix OMZL::directories OMZL::functions"
 )
@@ -216,6 +219,11 @@ zi_annex_meta_plugins_config_map=(
 _std+=" is-snippet"
 
 zi_annex_meta_plugins_config_map+=(
+  # Prezto
+  PZTM::archive       "$_std svn silent nocompile"
+  PZTM::directory     "$_std"
+  PZTM::utility       "$_std"
+
   # Oh-My-Zsh Library
   OMZL::git                   "$_std"
   OMZL::history               "$_std"


### PR DESCRIPTION
## Summary

- restore `@prezto` with `PZTM::archive`, `PZTM::directory`, and `PZTM::utility`
- configure the archive module as a directory snippet backed by Zi Git sparse-checkout support
- add a focused regression for registration and before-load expansion
- intentionally leave `@ohmyzsh-svn-lib` unavailable

## Dependency

Requires the Git sparse directory-snippet backend promoted to Zi `main` by [z-shell/zi#420](https://github.com/z-shell/zi/pull/420), originating in [z-shell/zi#417](https://github.com/z-shell/zi/pull/417).

## Verification

- `zsh -f tests/before-load-handler.zsh`
- `zsh -f tests/prezto-meta-plugin.zsh`
- native `zsh -n` across the plugin, function handlers, and tests
- `git diff --check`

No migration is required. Existing meta-plugin names and expansions are unchanged.