### PR TITLE
ci: pin zsh-lint workflow to v1.0.0

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   zsh-lint:
     name: Zsh Lint
-    uses: z-shell/.github/.github/workflows/zsh-lint.yml@e9cad163297f84eb2c315ac36da82877f0504a01
+    uses: z-shell/.github/.github/workflows/zsh-lint.yml@1b790f9ac271fbec149f8c92cd9c4fb2e59cc6ac # zsh-lint/v1.0.0
     with:
       zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
       paths: |


### PR DESCRIPTION
## Summary

- pin the reusable Zsh Lint workflow to the full SHA associated with immutable
  release `zsh-lint/v1.0.0`;
- add the release tag as the same-line version comment for auditability and
  dependency automation;
- leave the independently pinned `zsh-lint-ref` and dependency configuration
  unchanged.

## Why

The previous untagged SHA caused Dependabot to follow unrelated commits in
`z-shell/.github`. The release-associated SHA keeps execution immutable while
giving dependency automation a workflow-specific release lineage.

## Verification

- `actionlint .github/workflows/zsh-lint.yml`
- `git diff --check`
- `gh release verify zsh-lint/v1.0.0 --repo z-shell/.github`
- release tag resolves to
  `1b790f9ac271fbec149f8c92cd9c4fb2e59cc6ac`

Tracking: z-shell/.github#543

Supersedes #47.
