### PR TITLE
docs: link canonical Zsh instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,5 +9,6 @@ This project follows the organization-wide [Z-Shell Organization Guidelines](htt
 ## Conventions
 
 - Adhere to the canonical [Zsh Plugin Standard](https://wiki.zshell.dev/community/zsh_plugin_standard).
-- Follow `.github/instructions/zsh-scripting.instructions.md`.
+- Follow the canonical
+  [Zsh Scripting Standard](https://github.com/z-shell/.github/blob/main/.github/instructions/zsh-scripting.instructions.md).
 - Entry point: `z-a-meta-plugins.plugin.zsh`


### PR DESCRIPTION
## Summary

- link repository-local guidance to the canonical organization Zsh scripting
  standard
- keep annex-specific entry-point guidance concise and local

## Verification

- cross-repository instruction contract: 88 tests passed
- `git diff --check origin/main...HEAD`
