### PR TITLE
fix: preserve caller state in annex entrypoint

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -8,12 +8,14 @@ on:
       - "z-a-meta-plugins.plugin.zsh"
       - "functions/**"
       - ".github/workflows/zsh-lint.yml"
+      - "zsh-lint.json"
   pull_request:
     branches: [main]
     paths:
       - "z-a-meta-plugins.plugin.zsh"
       - "functions/**"
       - ".github/workflows/zsh-lint.yml"
+      - "zsh-lint.json"
   workflow_dispatch: {}
 
 permissions:
@@ -25,10 +27,36 @@ concurrency:
 
 jobs:
   zsh-lint:
-    name: Zsh Lint
-    uses: z-shell/.github/.github/workflows/zsh-lint.yml@1b790f9ac271fbec149f8c92cd9c4fb2e59cc6ac # zsh-lint/v1.0.0
-    with:
-      zsh-lint-ref: 900560008382fcdfbed9c2ff26129438d44a1359
-      paths: |
-        z-a-meta-plugins.plugin.zsh
-        functions
+    name: Configured Zsh Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check out zsh-lint
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-lint
+          ref: 1e8b0a6c02d4aa433e6aee8ca141e11ef62ba76b
+          path: .zsh-lint-tool
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          go-version: "1.25"
+      - name: Build zsh-lint
+        run: go build -C .zsh-lint-tool -o "$RUNNER_TEMP/zsh-lint" ./cmd/zsh-lint
+      - name: Run configured advisory profile
+        shell: bash
+        env:
+          ZSH_LINT_PATHS: |
+            z-a-meta-plugins.plugin.zsh
+            functions
+        run: |
+          set -euo pipefail
+          mapfile -t targets < <(printf '%s\n' "$ZSH_LINT_PATHS" | sed '/^[[:space:]]*$/d')
+          find -- "${targets[@]}" -type f -print0 | sort -z > "$RUNNER_TEMP/zsh-lint-files"
+          mapfile -d '' files < "$RUNNER_TEMP/zsh-lint-files"
+          "$RUNNER_TEMP/zsh-lint" --config zsh-lint.json "${files[@]}"

--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -28,7 +28,7 @@ jobs:
     name: Zsh Lint
     uses: z-shell/.github/.github/workflows/zsh-lint.yml@1b790f9ac271fbec149f8c92cd9c4fb2e59cc6ac # zsh-lint/v1.0.0
     with:
-      zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
+      zsh-lint-ref: 900560008382fcdfbed9c2ff26129438d44a1359
       paths: |
         z-a-meta-plugins.plugin.zsh
         functions

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -9,10 +9,12 @@ on:
     paths:
       - "*.zsh"
       - "functions/*"
+      - "tests/**"
   pull_request:
     paths:
       - "*.zsh"
       - "functions/*"
+      - "tests/**"
   workflow_dispatch: {}
 
 permissions:
@@ -58,3 +60,19 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: "⚡ Install dependencies"
+        run: sudo apt update && sudo apt-get install -yq zsh
+      - name: "🧪 Run test suite"
+        run: |
+          zsh -f -c '
+            setopt err_exit
+            for test_file in tests/*.zsh; do
+              print -r -- "== $test_file"
+              zsh -f "$test_file"
+            done
+          '

--- a/tests/entrypoint-state.zsh
+++ b/tests/entrypoint-state.zsh
@@ -1,0 +1,51 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -R zsh
+
+typeset repo_dir=${0:A:h:h}
+typeset entrypoint=$repo_dir/z-a-meta-plugins.plugin.zsh
+
+fail() {
+  builtin print -u2 -r -- "not ok - $1"
+  exit 1
+}
+
+if [[ $1 != --case ]]; then
+  for option_mode in default no_function_argzero posix_argzero; do
+    for source_mode in direct manager_zero; do
+      zsh -f "${0:A}" --case "$option_mode" "$source_mode" ||
+        fail "$option_mode/$source_mode"
+    done
+  done
+  builtin print -r -- 'ok - preserve caller state and resolve the annex directory'
+  exit 0
+fi
+
+case $2 in
+  default) ;;
+  no_function_argzero) unsetopt function_argzero ;;
+  posix_argzero) setopt posix_argzero ;;
+  *) fail "unknown option mode: $2" ;;
+esac
+
+function @zi-register-annex() { :; }
+typeset -g PMSPEC=f
+typeset -gA Plugins
+
+if [[ $3 == manager_zero ]]; then
+  typeset -g ZERO=$entrypoint
+else
+  unset ZERO
+fi
+
+typeset caller_zero=$0
+builtin source "$entrypoint" >/dev/null || fail 'source annex entrypoint'
+[[ $0 == "$caller_zero" ]] || fail 'preserve caller 0'
+[[ ${zi_annex_meta_plugins[0]} == "$entrypoint" ]] || fail 'record source path'
+[[ ${zi_annex_meta_plugins[repo-dir]} == "$repo_dir" ]] || fail 'record annex directory'
+[[ ${Plugins[META_PLUGINS_DIR]} == "$repo_dir" ]] || fail 'record plugin directory'
+
+builtin source "$entrypoint" >/dev/null || fail 're-source annex entrypoint'
+[[ $0 == "$caller_zero" ]] || fail 'preserve caller 0 after re-source'

--- a/z-a-meta-plugins.plugin.zsh
+++ b/z-a-meta-plugins.plugin.zsh
@@ -3,22 +3,25 @@
 #
 # Copyright (c) 2021 Z-Shell Community
 #
-# https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling
-0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
-0="${${(M)0:#/*}:-$PWD/$0}"
+# Preserve caller state while resolving this sourced entrypoint.
+() {
+  builtin emulate -L zsh
+
+  typeset -r source_path="${${(M)1:#/*}:-$PWD/$1}"
+  typeset -r annex_dir=${source_path:h}
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard/#funtions-directory
 if [[ $PMSPEC != *f* ]] {
-  fpath+=( "${0:h}/functions" )
+  fpath+=( "${annex_dir}/functions" )
 }
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard#standard-plugins-hash
 typeset -gA zi_annex_meta_plugins
-zi_annex_meta_plugins[0]="$0"
-zi_annex_meta_plugins[repo-dir]="${0:h}"
+zi_annex_meta_plugins[0]="$source_path"
+zi_annex_meta_plugins[repo-dir]="$annex_dir"
 
 typeset -gA Plugins
-Plugins[META_PLUGINS_DIR]="${0:h}"
+Plugins[META_PLUGINS_DIR]="$annex_dir"
 
 # Autoload functions
 # TODO: meta-cmd  meta-cmd-help-handler
@@ -240,3 +243,4 @@ zi_annex_meta_plugins_config_map+=(
 )
 
 unset _std
+} "${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"

--- a/zsh-lint.json
+++ b/zsh-lint.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "zi-annex",
+    "minimum_zsh": "5.9.2",
+    "function_namespaces": ["za-meta-plugins"]
+  },
+  "sources": [
+    { "root": "z-a-meta-plugins.plugin.zsh", "profile": "sourced-library" },
+    { "root": "functions", "profile": "autoload-function" }
+  ]
+}


### PR DESCRIPTION
Closes #52.

## Summary

- resolve the annex source path inside a localized anonymous-function boundary
- stop assigning to special parameter `0`
- use the resolved directory for annex metadata and `fpath`
- add a six-case caller-state regression test and run the repository's runtime tests in CI

## Validation

- all native Zsh syntax checks passed
- `tests/before-load-handler.zsh` passed
- `tests/prezto-meta-plugin.zsh` passed
- `tests/entrypoint-state.zsh` passed for default, `no_function_argzero`, and `posix_argzero`, using both direct sourcing and manager-supplied `ZERO`
- actionlint passed
- Trunk reported no source findings; its local gitleaks adapter could not launch because the pinned cache binary was absent, so hosted checks remain authoritative for that adapter

Roadmap: z-shell/zsh-lint#138. Rule prerequisite: z-shell/zsh-lint#160.
